### PR TITLE
release fd when got fd but not create listener

### DIFF
--- a/reuseport.go
+++ b/reuseport.go
@@ -67,6 +67,12 @@ func NewReusablePortListener(proto, addr string) (l net.Listener, err error) {
 		return nil, err
 	}
 
+	defer func() {
+		if err != nil {
+			syscall.Close(fd)
+		}
+	}()
+
 	if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, reusePort, 1); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When we use syscall.Socket that successfully get the fd ,but the following program meets some error,the fd can not be released.In the PR,use defer and err to check if it is necessary to release the fd