### PR TITLE
using max listener backlog

### DIFF
--- a/reuseport.go
+++ b/reuseport.go
@@ -22,6 +22,8 @@ const (
 	filePrefix            = "port."
 )
 
+var listenerBacklog = maxListenerBacklog()
+
 // getSockaddr parses protocol and address and returns implementor syscall.Sockaddr: syscall.SockaddrInet4 or syscall.SockaddrInet6.
 func getSockaddr(proto, addr string) (sa syscall.Sockaddr, soType int, err error) {
 	var (
@@ -86,7 +88,7 @@ func NewReusablePortListener(proto, addr string) (l net.Listener, err error) {
 	}
 
 	// Set backlog size to the maximum
-	if err = syscall.Listen(fd, syscall.SOMAXCONN); err != nil {
+	if err = syscall.Listen(fd, listenerBacklog); err != nil {
 		return nil, err
 	}
 

--- a/reuseport_bsd.go
+++ b/reuseport_bsd.go
@@ -2,6 +2,34 @@
 
 package reuseport
 
-import "syscall"
+import (
+	"runtime"
+	"syscall"
+)
 
 var reusePort = syscall.SO_REUSEPORT
+
+func maxListenerBacklog() int {
+	var (
+		n   uint32
+		err error
+	)
+	switch runtime.GOOS {
+	case "darwin", "freebsd":
+		n, err = syscall.SysctlUint32("kern.ipc.somaxconn")
+	case "netbsd":
+		// NOTE: NetBSD has no somaxconn-like kernel state so far
+	case "openbsd":
+		n, err = syscall.SysctlUint32("kern.somaxconn")
+	}
+	if n == 0 || err != nil {
+		return syscall.SOMAXCONN
+	}
+	// FreeBSD stores the backlog in a uint16, as does Linux.
+	// Assume the other BSDs do too. Truncate number to avoid wrapping.
+	// See issue 5030.
+	if n > 1<<16-1 {
+		n = 1<<16 - 1
+	}
+	return int(n)
+}

--- a/reuseport_linux.go
+++ b/reuseport_linux.go
@@ -1,3 +1,39 @@
 package reuseport
 
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
 var reusePort = 0x0F
+
+func maxListenerBacklog() int {
+	fd, err := os.Open("/proc/sys/net/core/somaxconn")
+	if err != nil {
+		return syscall.SOMAXCONN
+	}
+	defer fd.Close()
+	rd := bufio.NewReader(fd)
+	line, err := rd.ReadString('\n')
+	if err != nil {
+		return syscall.SOMAXCONN
+	}
+	f := strings.Fields(line)
+	if len(f) < 1 {
+		return syscall.SOMAXCONN
+	}
+	n, err := strconv.Atoi(f[0])
+	if err != nil || n == 0 {
+		return syscall.SOMAXCONN
+	}
+	// Linux stores the backlog in a uint16.
+	// Truncate number to avoid wrapping.
+	// See issue 5030.
+	if n > 1<<16-1 {
+		n = 1<<16 - 1
+	}
+	return n
+}


### PR DESCRIPTION
"syscall.SOMAXCONN" maybe not the maximum size, listenerBacklog in golang:

https://github.com/golang/go/blob/master/src/net/sock_linux.go
https://github.com/golang/go/blob/master/src/net/sock_bsd.go
https://github.com/golang/go/blob/master/src/net/net.go#L341
https://github.com/golang/go/blob/master/src/net/sock_posix.go#L76