### PR TITLE
Allow broadcast

### DIFF
--- a/udp.go
+++ b/udp.go
@@ -122,6 +122,10 @@ func NewReusablePortPacketConn(proto, addr string) (l net.PacketConn, err error)
 		return nil, err
 	}
 
+	if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_BROADCAST, 1); err != nil {
+		return nil, err
+	}
+
 	if err = syscall.Bind(fd, sockaddr); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use SO_BROADCAST to allow broadcast.  This is similar to how the Go
standard library behaves. For example, see
https://golang.org/src/net/sockopt_linux.go