### PR TITLE
Fix slice bounds out of range on address copy

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -40,7 +40,11 @@ func getTCPSockaddr(proto, addr string) (sa syscall.Sockaddr, soType int, err er
 		sa := &syscall.SockaddrInet4{Port: tcp.Port}
 
 		if tcp.IP != nil {
-			copy(sa.Addr[:], tcp.IP[12:16]) // copy last 4 bytes of slice to array
+			if len(tcp.IP) == 16 {
+				copy(sa.Addr[:], tcp.IP[12:16]) // copy last 4 bytes of slice to array
+			} else {
+				copy(sa.Addr[:], tcp.IP) // copy all bytes of slice to array
+			}
 		}
 
 		return sa, syscall.AF_INET, nil

--- a/udp.go
+++ b/udp.go
@@ -37,7 +37,11 @@ func getUDPSockaddr(proto, addr string) (sa syscall.Sockaddr, soType int, err er
 		sa := &syscall.SockaddrInet4{Port: udp.Port}
 
 		if udp.IP != nil {
-			copy(sa.Addr[:], udp.IP[12:16]) // copy last 4 bytes of slice to array
+			if len(udp.IP) == 16 {
+				copy(sa.Addr[:], udp.IP[12:16]) // copy last 4 bytes of slice to array
+			} else {
+				copy(sa.Addr[:], udp.IP) // copy all bytes of slice to array
+			}
 		}
 
 		return sa, syscall.AF_INET, nil


### PR DESCRIPTION
Hi @kavu! This pull request aims to fix a panic we encountered in ghostunnel (for detailed info see https://github.com/square/ghostunnel/issues/200). I think this change should address the issue, but if you think there's a better way to fix this let me know. 

The gist of the issue is that IP address embedded in a `net.TCPAddr` (or `net.UDPAddr`) struct returned from `net.ResolveTCPAddr` (or `net.ResolveUDPAddr`) can be either a 4-byte or 16-byte slice depending on platform and configuration. To avoid a potential panic in the case where a 4-byte slice is returned we must check the length of the address before copying it into the `syscall.Sockaddr` struct.