### PR TITLE
Remove bogus check for tcp.IP and udp.IP.

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -24,7 +24,7 @@ func getTCPSockaddr(proto, addr string) (sa syscall.Sockaddr, soType int, err er
 	var tcp *net.TCPAddr
 
 	tcp, err = net.ResolveTCPAddr(proto, addr)
-	if err != nil && tcp.IP != nil {
+	if err != nil {
 		return nil, -1, err
 	}
 

--- a/udp.go
+++ b/udp.go
@@ -21,7 +21,7 @@ func getUDPSockaddr(proto, addr string) (sa syscall.Sockaddr, soType int, err er
 	var udp *net.UDPAddr
 
 	udp, err = net.ResolveUDPAddr(proto, addr)
-	if err != nil && udp.IP != nil {
+	if err != nil {
 		return nil, -1, err
 	}
 


### PR DESCRIPTION
When ResolveUDPAddr returns an error, it returns a nil *UDPAddr, so
checking udp.IP causes a segfault.